### PR TITLE
fix: When page is loaded with column set to not visible, the formatting wasn't initialised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 
+## [1.5.7] - 2024-05-27
+
+### Fixed
+- Fixed bug when page is loaded with column set to not visible, the formatting wasn't initialised. 
+  Making it so when you set the col to visible, the formatting won't show (stars on rating in example proj)
+
 ## [1.5.6] - 2020-07-06
 
 ### Fixed

--- a/projects/smart-table/src/lib/services/table.factory.ts
+++ b/projects/smart-table/src/lib/services/table.factory.ts
@@ -24,7 +24,6 @@ export class TableFactory {
       hidden: !(columnConfig.visible || columnConfig.visible == null),
       disableSorting: !columnConfig.sortPath
     };
-    if (columnConfig.visible || columnConfig.visible == null) {
       if (Array.isArray(columnConfig.classList) && columnConfig.classList.length) {
         column.classList = columnConfig.classList;
       }
@@ -46,7 +45,6 @@ export class TableFactory {
             break;
           }
         }
-      }
     }
     return column;
   }


### PR DESCRIPTION
Fixed bug when page is loaded with column set to not visible, the formatting wasn't initialised. 
Making it so when you set the col to visible, the formatting won't show (stars on rating in example proj).

By initalising all formatting on page load, this isn't an issue anymore.